### PR TITLE
Add my bugfix for the session token issue

### DIFF
--- a/MHPatcher/Patches64.json
+++ b/MHPatcher/Patches64.json
@@ -1,5 +1,11 @@
 ﻿[
 	{
+		"Name": "Fix Session Token Encryption by TobiX",
+		"IsEnabled": false,
+		"Offset": "0x005CC5D6",
+		"Data": "C7000802000090909090904189F8"
+	},
+	{
 		"Name": "Bypass Session Token Encryption Error by FF_Lowthor",
 		"IsEnabled": false,
 		"Offset": "0x019B317E",


### PR DESCRIPTION
This should do the same as my XDelta patch (see https://tobix.github.io/mh-linux-patch/, the patch file is in https://github.com/TobiX/tobix.github.io/blob/main/mh-linux-patch/patches.zip), but I had no chance to verify it yet, since I have no Windows .NET development environment setup...
